### PR TITLE
Fix illformed requirement when gem has multiple version constraints

### DIFF
--- a/lib/rails_bump/checker/bundle_locally_check.rb
+++ b/lib/rails_bump/checker/bundle_locally_check.rb
@@ -79,7 +79,9 @@ module RailsBump
         GEMFILE
 
         @dependencies.each do |gem_name, gem_version|
-          result += "gem '#{gem_name}', '#{gem_version}'\n" unless gem_name == "rails"
+          next if gem_name == "rails"
+          versions = gem_version.split(",").map { |v| "'#{v.strip}'" }.join(", ")
+          result += "gem '#{gem_name}', #{versions}\n"
         end
 
         result

--- a/spec/rails_bump/checker/bundle_locally_check_spec.rb
+++ b/spec/rails_bump/checker/bundle_locally_check_spec.rb
@@ -1,6 +1,38 @@
 require "spec_helper"
 
 RSpec.describe RailsBump::Checker::BundleLocallyCheck do
+  describe "#gemfile_content" do
+    subject(:content) { checker.send(:gemfile_content) }
+
+    let(:checker) { described_class.new(rails_version: "7.1.0", dependencies: deps) }
+
+    context "with a single version constraint" do
+      let(:deps) { {"sidekiq" => ">= 6"} }
+
+      it "formats the gem line with a single version argument" do
+        expect(content).to include("gem 'sidekiq', '>= 6'")
+      end
+    end
+
+    context "with multiple version constraints separated by a comma" do
+      let(:deps) { {"some_gem" => ">= 1.0, < 2.0"} }
+
+      it "formats the gem line with each constraint as a separate argument" do
+        expect(content).to include("gem 'some_gem', '>= 1.0', '< 2.0'")
+      end
+    end
+
+    context "when a dependency is rails" do
+      let(:deps) { {"rails" => "6.0.0"} }
+
+      it "skips the rails dependency (rails version comes from the checker)" do
+        # Only the rails line from the header should appear, not a duplicate
+        expect(content.scan("gem 'rails'").count).to eq(1)
+        expect(content).to include("gem 'rails', '7.1.0'")
+      end
+    end
+  end
+
   describe "#check" do
     let(:deps) do
       {"cronex" => ">= 0.13.0", "fugit" => "~> 1.8", "globalid" => ">= 1.0.1", "sidekiq" => ">= 6"}


### PR DESCRIPTION
## Summary

- Fixes the `Illformed requirement` Bundler error that occurs when a gem dependency has comma-separated version constraints (e.g. `">= 2.0, < 3.2"`)
- Splits version constraints on commas and emits each as a separate argument in the generated Gemfile, which is the correct Gemfile syntax
- Adds unit tests for `gemfile_content` covering single constraint, multiple constraints, and rails gem exclusion

Closes #8
Supersedes #10

## Test plan

- [x] `bundle exec rspec spec/rails_bump/checker/bundle_locally_check_spec.rb` passes
- [x] Verify gems with multi-constraint versions (e.g. faraday) no longer raise `Illformed requirement`