### PR TITLE
fix(checker): scope temp cleanup to per-run directories

### DIFF
--- a/lib/rails_bump/checker.rb
+++ b/lib/rails_bump/checker.rb
@@ -3,6 +3,7 @@
 require "bundler"
 require_relative "checker/version"
 require_relative "checker/result"
+require_relative "checker/temp_bundle_runner"
 require_relative "checker/bundle_locally_check"
 require_relative "checker/rails_release_check"
 require_relative "checker/result_reporter"

--- a/lib/rails_bump/checker/bundle_locally_check.rb
+++ b/lib/rails_bump/checker/bundle_locally_check.rb
@@ -1,6 +1,6 @@
 require "fileutils"
 require "stringio"
-require "securerandom"
+require "tmpdir"
 
 module RailsBump
   module Checker
@@ -34,12 +34,11 @@ module RailsBump
         end
 
         begin
-          # Ensure the tmp directory exists
-          FileUtils.mkdir_p("tmp")
-
           # Set up the environment and definition
           Bundler.with_unbundled_env do
-            @captured_output = try_bundle_install
+            with_tmp_dir do |tmp_dir|
+              @captured_output = try_bundle_install(tmp_dir)
+            end
 
             puts "✅ Compatible dependencies"
             @result = Result.new(
@@ -61,9 +60,6 @@ module RailsBump
             strategy: self.class.name,
             output: "#{@captured_output}\n\nBundler error: #{err.message}\n\n#{err.backtrace}"
           )
-        ensure
-          puts "Cleaning up temporary files..."
-          cleanup_tmp_dir
         end
 
         @result
@@ -71,12 +67,11 @@ module RailsBump
 
       private
 
-      def tmp_dir
-        @tmp_dir ||= File.join("tmp", SecureRandom.hex(8))
-      end
-
-      def cleanup_tmp_dir
-        FileUtils.rm_rf(@tmp_dir) if @tmp_dir
+      def with_tmp_dir
+        FileUtils.mkdir_p("tmp")
+        Dir.mktmpdir("checker-", "tmp") do |tmp_dir|
+          yield tmp_dir
+        end
       end
 
       # Create a temporary Gemfile with the specified dependencies
@@ -95,11 +90,7 @@ module RailsBump
         result
       end
 
-      def try_bundle_install
-        FileUtils.mkdir_p(tmp_dir)
-
-        FileUtils.rm_rf File.join(tmp_dir, "Gemfile")
-        FileUtils.rm_rf File.join(tmp_dir, "Gemfile.lock")
+      def try_bundle_install(tmp_dir)
 
         # Clean Bundler cache
         `bundle clean --force`

--- a/lib/rails_bump/checker/bundle_locally_check.rb
+++ b/lib/rails_bump/checker/bundle_locally_check.rb
@@ -63,13 +63,21 @@ module RailsBump
           )
         ensure
           puts "Cleaning up temporary files..."
-          FileUtils.rm_rf("tmp")
+          cleanup_tmp_dir
         end
 
         @result
       end
 
       private
+
+      def tmp_dir
+        @tmp_dir ||= File.join("tmp", SecureRandom.hex(8))
+      end
+
+      def cleanup_tmp_dir
+        FileUtils.rm_rf(@tmp_dir) if @tmp_dir
+      end
 
       # Create a temporary Gemfile with the specified dependencies
       def gemfile_content
@@ -88,8 +96,6 @@ module RailsBump
       end
 
       def try_bundle_install
-        # Create a random temporary directory
-        tmp_dir = File.join("tmp", SecureRandom.hex(8))
         FileUtils.mkdir_p(tmp_dir)
 
         FileUtils.rm_rf File.join(tmp_dir, "Gemfile")
@@ -112,8 +118,6 @@ module RailsBump
         ensure
           @captured_output = $stdout.string
           $stdout = original_stdout
-          # Clean up the temporary directory
-          FileUtils.rm_rf(tmp_dir)
         end
 
         @captured_output

--- a/lib/rails_bump/checker/bundle_locally_check.rb
+++ b/lib/rails_bump/checker/bundle_locally_check.rb
@@ -1,10 +1,8 @@
-require "fileutils"
-require "stringio"
-require "tmpdir"
-
 module RailsBump
   module Checker
     class BundleLocallyCheck
+      include TempBundleRunner
+
       def initialize(opts = {})
         @rails_version = opts[:rails_version] || "9.1.0"
         @dependencies = opts[:dependencies] || []
@@ -36,9 +34,7 @@ module RailsBump
         begin
           # Set up the environment and definition
           Bundler.with_unbundled_env do
-            with_tmp_dir do |tmp_dir|
-              @captured_output = try_bundle_install(tmp_dir)
-            end
+            @captured_output = try_bundle_install
 
             puts "✅ Compatible dependencies"
             @result = Result.new(
@@ -67,13 +63,6 @@ module RailsBump
 
       private
 
-      def with_tmp_dir
-        FileUtils.mkdir_p("tmp")
-        Dir.mktmpdir("checker-", "tmp") do |tmp_dir|
-          yield tmp_dir
-        end
-      end
-
       # Create a temporary Gemfile with the specified dependencies
       def gemfile_content
         result = <<~GEMFILE
@@ -90,28 +79,12 @@ module RailsBump
         result
       end
 
-      def try_bundle_install(tmp_dir)
-
-        # Clean Bundler cache
-        `bundle clean --force`
-
-        File.write(File.join(tmp_dir, "Gemfile"), gemfile_content)
-
-        puts "Checking with temporary Gemfile: \n\n#{gemfile_content}\n\n"
-
-        # Build the definition from the temporary Gemfile
-        definition = Bundler::Definition.build(File.join(tmp_dir, "Gemfile"), File.join(tmp_dir, "Gemfile.lock"), nil)
-
-        original_stdout = $stdout
-        $stdout = StringIO.new
-        begin
-          Bundler::Installer.install(File.join(tmp_dir, "Gemfile"), definition, force: true, jobs: 4)
-        ensure
-          @captured_output = $stdout.string
-          $stdout = original_stdout
-        end
-
-        @captured_output
+      def try_bundle_install
+        run_bundle_install(
+          gemfile_content: gemfile_content,
+          installer_options: {force: true, jobs: 4},
+          clean_bundle_cache: true
+        )
       end
     end
   end

--- a/lib/rails_bump/checker/rails_release_check.rb
+++ b/lib/rails_bump/checker/rails_release_check.rb
@@ -1,6 +1,6 @@
 require "fileutils"
-require "securerandom"
 require "stringio"
+require "tmpdir"
 
 module RailsBump
   module Checker
@@ -18,12 +18,11 @@ module RailsBump
         puts "Rails version #{@rails_version}"
 
         begin
-          # Ensure the tmp directory exists
-          FileUtils.mkdir_p("tmp")
-
           # Set up the environment and definition
           Bundler.with_unbundled_env do
-            @captured_output = try_bundle_install
+            with_tmp_dir do |tmp_dir|
+              @captured_output = try_bundle_install(tmp_dir)
+            end
 
             puts "✅ Compatible dependencies"
             @result = Result.new(
@@ -41,9 +40,6 @@ module RailsBump
             strategy: self.class.name,
             output: "#{@captured_output}\n\nBundler error: #{err.message}\n\n#{err.backtrace}"
           )
-        ensure
-          puts "Cleaning up temporary files..."
-          cleanup_tmp_dir
         end
 
         @result
@@ -51,12 +47,11 @@ module RailsBump
 
       private
 
-      def tmp_dir
-        @tmp_dir ||= File.join("tmp", SecureRandom.hex(8))
-      end
-
-      def cleanup_tmp_dir
-        FileUtils.rm_rf(@tmp_dir) if @tmp_dir
+      def with_tmp_dir
+        FileUtils.mkdir_p("tmp")
+        Dir.mktmpdir("checker-", "tmp") do |tmp_dir|
+          yield tmp_dir
+        end
       end
 
       # Create a temporary Gemfile with the specified dependencies
@@ -68,10 +63,7 @@ module RailsBump
         GEMFILE
       end
 
-      def try_bundle_install
-        FileUtils.mkdir_p(tmp_dir)
-        FileUtils.rm_rf File.join(tmp_dir, "Gemfile")
-        FileUtils.rm_rf File.join(tmp_dir, "Gemfile.lock")
+      def try_bundle_install(tmp_dir)
 
         File.write(File.join(tmp_dir, "Gemfile"), gemfile_content)
 

--- a/lib/rails_bump/checker/rails_release_check.rb
+++ b/lib/rails_bump/checker/rails_release_check.rb
@@ -1,10 +1,8 @@
-require "fileutils"
-require "stringio"
-require "tmpdir"
-
 module RailsBump
   module Checker
     class RailsReleaseCheck
+      include TempBundleRunner
+
       def initialize(opts = {})
         @rails_version = opts[:rails_version] || "9.1.0"
         @captured_output = ""
@@ -20,9 +18,7 @@ module RailsBump
         begin
           # Set up the environment and definition
           Bundler.with_unbundled_env do
-            with_tmp_dir do |tmp_dir|
-              @captured_output = try_bundle_install(tmp_dir)
-            end
+            @captured_output = try_bundle_install
 
             puts "✅ Compatible dependencies"
             @result = Result.new(
@@ -47,13 +43,6 @@ module RailsBump
 
       private
 
-      def with_tmp_dir
-        FileUtils.mkdir_p("tmp")
-        Dir.mktmpdir("checker-", "tmp") do |tmp_dir|
-          yield tmp_dir
-        end
-      end
-
       # Create a temporary Gemfile with the specified dependencies
       def gemfile_content
         versions = @rails_version.split(",").map { |v| "'#{v.strip}'" }.join(", ")
@@ -63,25 +52,8 @@ module RailsBump
         GEMFILE
       end
 
-      def try_bundle_install(tmp_dir)
-
-        File.write(File.join(tmp_dir, "Gemfile"), gemfile_content)
-
-        puts "Checking with temporary Gemfile: \n\n#{gemfile_content}\n\n"
-
-        # Build the definition from the temporary Gemfile
-        definition = Bundler::Definition.build(File.join(tmp_dir, "Gemfile"), File.join(tmp_dir, "Gemfile.lock"), nil)
-
-        original_stdout = $stdout
-        $stdout = StringIO.new
-        begin
-          Bundler::Installer.install(File.join(tmp_dir, "Gemfile"), definition)
-        ensure
-          @captured_output = $stdout.string
-          $stdout = original_stdout
-        end
-
-        @captured_output
+      def try_bundle_install
+        run_bundle_install(gemfile_content: gemfile_content)
       end
     end
   end

--- a/lib/rails_bump/checker/rails_release_check.rb
+++ b/lib/rails_bump/checker/rails_release_check.rb
@@ -43,7 +43,7 @@ module RailsBump
           )
         ensure
           puts "Cleaning up temporary files..."
-          FileUtils.rm_rf("tmp")
+          cleanup_tmp_dir
         end
 
         @result
@@ -53,6 +53,10 @@ module RailsBump
 
       def tmp_dir
         @tmp_dir ||= File.join("tmp", SecureRandom.hex(8))
+      end
+
+      def cleanup_tmp_dir
+        FileUtils.rm_rf(@tmp_dir) if @tmp_dir
       end
 
       # Create a temporary Gemfile with the specified dependencies
@@ -83,7 +87,6 @@ module RailsBump
         ensure
           @captured_output = $stdout.string
           $stdout = original_stdout
-          FileUtils.rm_rf(tmp_dir)
         end
 
         @captured_output

--- a/lib/rails_bump/checker/temp_bundle_runner.rb
+++ b/lib/rails_bump/checker/temp_bundle_runner.rb
@@ -1,0 +1,46 @@
+require "fileutils"
+require "stringio"
+require "tmpdir"
+
+module RailsBump
+  module Checker
+    module TempBundleRunner
+      private
+
+      def run_bundle_install(gemfile_content:, installer_options: {}, clean_bundle_cache: false)
+        with_tmp_dir do |tmp_dir|
+          `bundle clean --force` if clean_bundle_cache
+
+          gemfile_path = File.join(tmp_dir, "Gemfile")
+          gemfile_lock_path = File.join(tmp_dir, "Gemfile.lock")
+
+          File.write(gemfile_path, gemfile_content)
+
+          puts "Checking with temporary Gemfile: \n\n#{gemfile_content}\n\n"
+
+          definition = Bundler::Definition.build(gemfile_path, gemfile_lock_path, nil)
+
+          capture_stdout do
+            Bundler::Installer.install(gemfile_path, definition, **installer_options)
+          end
+        end
+      end
+
+      def with_tmp_dir
+        FileUtils.mkdir_p("tmp")
+        Dir.mktmpdir("checker-", "tmp") do |tmp_dir|
+          yield tmp_dir
+        end
+      end
+
+      def capture_stdout
+        original_stdout = $stdout
+        $stdout = StringIO.new
+        yield
+        $stdout.string
+      ensure
+        $stdout = original_stdout
+      end
+    end
+  end
+end

--- a/spec/rails_bump/checker/bundle_locally_check_spec.rb
+++ b/spec/rails_bump/checker/bundle_locally_check_spec.rb
@@ -121,12 +121,9 @@ RSpec.describe RailsBump::Checker::BundleLocallyCheck do
         rails_version: "7.1.0",
         dependencies: {"rack" => ">= 2.0"}
       )
-      scoped_tmp_dir = "tmp/checker-scope-test"
 
-      allow(checker).to receive(:try_bundle_install).with(scoped_tmp_dir).and_return("ok")
+      expect(checker).to receive(:try_bundle_install).and_return("ok")
       allow(Bundler).to receive(:with_unbundled_env).and_yield
-      allow(FileUtils).to receive(:mkdir_p)
-      expect(Dir).to receive(:mktmpdir).with("checker-", "tmp").and_yield(scoped_tmp_dir)
 
       checker.check
     end

--- a/spec/rails_bump/checker/bundle_locally_check_spec.rb
+++ b/spec/rails_bump/checker/bundle_locally_check_spec.rb
@@ -1,18 +1,17 @@
 require "spec_helper"
 
 RSpec.describe RailsBump::Checker::BundleLocallyCheck do
-  describe "#tmp_dir" do
-    it "is unique per instance so concurrent runs do not collide" do
-      checker_a = described_class.new(rails_version: "7.1.0", dependencies: {"rack" => ">= 2.0"})
-      checker_b = described_class.new(rails_version: "7.2.0", dependencies: {"rack" => ">= 2.0"})
-
-      expect(checker_a.send(:tmp_dir)).not_to eq(checker_b.send(:tmp_dir))
-    end
-
-    it "is stable within the same instance" do
+  describe "#with_tmp_dir" do
+    it "creates a checker-scoped temporary directory under tmp" do
       checker = described_class.new(rails_version: "7.1.0", dependencies: {"rack" => ">= 2.0"})
 
-      expect(checker.send(:tmp_dir)).to eq(checker.send(:tmp_dir))
+      allow(FileUtils).to receive(:mkdir_p)
+      expect(Dir).to receive(:mktmpdir).with("checker-", "tmp").and_yield("tmp/checker-scope-test")
+
+      yielded = nil
+      checker.send(:with_tmp_dir) { |tmp_dir| yielded = tmp_dir }
+
+      expect(yielded).to eq("tmp/checker-scope-test")
     end
   end
 
@@ -117,21 +116,17 @@ RSpec.describe RailsBump::Checker::BundleLocallyCheck do
       end
     end
 
-    it "cleans up only the checker scoped temp directory" do
+    it "uses Dir.mktmpdir scoped under tmp" do
       checker = described_class.new(
         rails_version: "7.1.0",
         dependencies: {"rack" => ">= 2.0"}
       )
       scoped_tmp_dir = "tmp/checker-scope-test"
 
-      checker.instance_variable_set(:@tmp_dir, scoped_tmp_dir)
-      allow(checker).to receive(:try_bundle_install).and_return("ok")
+      allow(checker).to receive(:try_bundle_install).with(scoped_tmp_dir).and_return("ok")
       allow(Bundler).to receive(:with_unbundled_env).and_yield
       allow(FileUtils).to receive(:mkdir_p)
-      allow(FileUtils).to receive(:rm_rf)
-
-      expect(FileUtils).to receive(:rm_rf).with(scoped_tmp_dir)
-      expect(FileUtils).not_to receive(:rm_rf).with("tmp")
+      expect(Dir).to receive(:mktmpdir).with("checker-", "tmp").and_yield(scoped_tmp_dir)
 
       checker.check
     end

--- a/spec/rails_bump/checker/bundle_locally_check_spec.rb
+++ b/spec/rails_bump/checker/bundle_locally_check_spec.rb
@@ -1,17 +1,14 @@
 require "spec_helper"
 
 RSpec.describe RailsBump::Checker::BundleLocallyCheck do
-  describe "#with_tmp_dir" do
-    it "creates a checker-scoped temporary directory under tmp" do
-      checker = described_class.new(rails_version: "7.1.0", dependencies: {"rack" => ">= 2.0"})
+  describe "temporary directory lifecycle" do
+    it "cleans up its temporary directory without removing tmp/" do
+      FileUtils.rm_rf(Dir.glob("tmp/checker-*"))
 
-      allow(FileUtils).to receive(:mkdir_p)
-      expect(Dir).to receive(:mktmpdir).with("checker-", "tmp").and_yield("tmp/checker-scope-test")
+      described_class.new(rails_version: "7.1.0", dependencies: {"rack" => ">= 2.0"}).check
 
-      yielded = nil
-      checker.send(:with_tmp_dir) { |tmp_dir| yielded = tmp_dir }
-
-      expect(yielded).to eq("tmp/checker-scope-test")
+      expect(Dir.glob("tmp/checker-*")).to be_empty
+      expect(Dir.exist?("tmp")).to be true
     end
   end
 
@@ -116,7 +113,7 @@ RSpec.describe RailsBump::Checker::BundleLocallyCheck do
       end
     end
 
-    it "uses Dir.mktmpdir scoped under tmp" do
+    it "attempts bundler install when dependencies are present" do
       checker = described_class.new(
         rails_version: "7.1.0",
         dependencies: {"rack" => ">= 2.0"}

--- a/spec/rails_bump/checker/bundle_locally_check_spec.rb
+++ b/spec/rails_bump/checker/bundle_locally_check_spec.rb
@@ -1,6 +1,21 @@
 require "spec_helper"
 
 RSpec.describe RailsBump::Checker::BundleLocallyCheck do
+  describe "#tmp_dir" do
+    it "is unique per instance so concurrent runs do not collide" do
+      checker_a = described_class.new(rails_version: "7.1.0", dependencies: {"rack" => ">= 2.0"})
+      checker_b = described_class.new(rails_version: "7.2.0", dependencies: {"rack" => ">= 2.0"})
+
+      expect(checker_a.send(:tmp_dir)).not_to eq(checker_b.send(:tmp_dir))
+    end
+
+    it "is stable within the same instance" do
+      checker = described_class.new(rails_version: "7.1.0", dependencies: {"rack" => ">= 2.0"})
+
+      expect(checker.send(:tmp_dir)).to eq(checker.send(:tmp_dir))
+    end
+  end
+
   describe "#gemfile_content" do
     subject(:content) { checker.send(:gemfile_content) }
 
@@ -100,6 +115,25 @@ RSpec.describe RailsBump::Checker::BundleLocallyCheck do
 
         expect(result.output.downcase).to include(msg.downcase)
       end
+    end
+
+    it "cleans up only the checker scoped temp directory" do
+      checker = described_class.new(
+        rails_version: "7.1.0",
+        dependencies: {"rack" => ">= 2.0"}
+      )
+      scoped_tmp_dir = "tmp/checker-scope-test"
+
+      checker.instance_variable_set(:@tmp_dir, scoped_tmp_dir)
+      allow(checker).to receive(:try_bundle_install).and_return("ok")
+      allow(Bundler).to receive(:with_unbundled_env).and_yield
+      allow(FileUtils).to receive(:mkdir_p)
+      allow(FileUtils).to receive(:rm_rf)
+
+      expect(FileUtils).to receive(:rm_rf).with(scoped_tmp_dir)
+      expect(FileUtils).not_to receive(:rm_rf).with("tmp")
+
+      checker.check
     end
   end
 end

--- a/spec/rails_bump/checker/rails_release_check_spec.rb
+++ b/spec/rails_bump/checker/rails_release_check_spec.rb
@@ -80,12 +80,9 @@ RSpec.describe RailsBump::Checker::RailsReleaseCheck do
 
     it "uses Dir.mktmpdir scoped under tmp" do
       checker = described_class.new(rails_version: "7.1.0")
-      scoped_tmp_dir = "tmp/release-scope-test"
 
-      allow(checker).to receive(:try_bundle_install).with(scoped_tmp_dir).and_return("ok")
+      expect(checker).to receive(:try_bundle_install).and_return("ok")
       allow(Bundler).to receive(:with_unbundled_env).and_yield
-      allow(FileUtils).to receive(:mkdir_p)
-      expect(Dir).to receive(:mktmpdir).with("checker-", "tmp").and_yield(scoped_tmp_dir)
 
       checker.check
     end

--- a/spec/rails_bump/checker/rails_release_check_spec.rb
+++ b/spec/rails_bump/checker/rails_release_check_spec.rb
@@ -29,18 +29,17 @@ RSpec.describe RailsBump::Checker::RailsReleaseCheck do
     end
   end
 
-  describe "#tmp_dir" do
-    it "is unique per instance so concurrent runs do not collide" do
-      checker_a = described_class.new(rails_version: "7.1.0")
-      checker_b = described_class.new(rails_version: "7.2.0")
-
-      expect(checker_a.send(:tmp_dir)).not_to eq(checker_b.send(:tmp_dir))
-    end
-
-    it "is stable within the same instance" do
+  describe "#with_tmp_dir" do
+    it "creates a checker-scoped temporary directory under tmp" do
       checker = described_class.new(rails_version: "7.1.0")
 
-      expect(checker.send(:tmp_dir)).to eq(checker.send(:tmp_dir))
+      allow(FileUtils).to receive(:mkdir_p)
+      expect(Dir).to receive(:mktmpdir).with("checker-", "tmp").and_yield("tmp/release-scope-test")
+
+      yielded = nil
+      checker.send(:with_tmp_dir) { |tmp_dir| yielded = tmp_dir }
+
+      expect(yielded).to eq("tmp/release-scope-test")
     end
   end
 
@@ -79,18 +78,14 @@ RSpec.describe RailsBump::Checker::RailsReleaseCheck do
       end
     end
 
-    it "cleans up only the checker scoped temp directory" do
+    it "uses Dir.mktmpdir scoped under tmp" do
       checker = described_class.new(rails_version: "7.1.0")
       scoped_tmp_dir = "tmp/release-scope-test"
 
-      checker.instance_variable_set(:@tmp_dir, scoped_tmp_dir)
-      allow(checker).to receive(:try_bundle_install).and_return("ok")
+      allow(checker).to receive(:try_bundle_install).with(scoped_tmp_dir).and_return("ok")
       allow(Bundler).to receive(:with_unbundled_env).and_yield
       allow(FileUtils).to receive(:mkdir_p)
-      allow(FileUtils).to receive(:rm_rf)
-
-      expect(FileUtils).to receive(:rm_rf).with(scoped_tmp_dir)
-      expect(FileUtils).not_to receive(:rm_rf).with("tmp")
+      expect(Dir).to receive(:mktmpdir).with("checker-", "tmp").and_yield(scoped_tmp_dir)
 
       checker.check
     end

--- a/spec/rails_bump/checker/rails_release_check_spec.rb
+++ b/spec/rails_bump/checker/rails_release_check_spec.rb
@@ -78,5 +78,21 @@ RSpec.describe RailsBump::Checker::RailsReleaseCheck do
         expect(result.success?).to be_truthy
       end
     end
+
+    it "cleans up only the checker scoped temp directory" do
+      checker = described_class.new(rails_version: "7.1.0")
+      scoped_tmp_dir = "tmp/release-scope-test"
+
+      checker.instance_variable_set(:@tmp_dir, scoped_tmp_dir)
+      allow(checker).to receive(:try_bundle_install).and_return("ok")
+      allow(Bundler).to receive(:with_unbundled_env).and_yield
+      allow(FileUtils).to receive(:mkdir_p)
+      allow(FileUtils).to receive(:rm_rf)
+
+      expect(FileUtils).to receive(:rm_rf).with(scoped_tmp_dir)
+      expect(FileUtils).not_to receive(:rm_rf).with("tmp")
+
+      checker.check
+    end
   end
 end


### PR DESCRIPTION
## Summary
This PR improves temporary-directory handling in the checkers by moving to `Dir.mktmpdir` and then follows up with a no-behavior-change refactor to remove duplication between checker implementations.

## What Changed
- Switched checker temp directory lifecycle to `Dir.mktmpdir("checker-", "tmp")`.
- Removed manual random directory generation and explicit cleanup methods.
- Kept temp work scoped under project `tmp/`.
- Added a shared internal helper module: `RailsBump::Checker::TempBundleRunner`.
- Extracted common flow into the helper:
  - tmp dir creation
  - temporary Gemfile/Gemfile.lock path setup
  - bundler definition/build + install
  - stdout capture/restoration
- Updated both checkers to keep only checker-specific behavior:
  - checker-specific Gemfile content
  - installer options (`force/jobs` in `BundleLocallyCheck`)
  - checker-specific result payload fields

## Commits
1. `def2d53` Refactor checker temp dir lifecycle to use `Dir.mktmpdir`
2. `5fd9bcf` refactor(checker): extract shared temp bundler runner

## Tests
- `bundle exec rspec spec/rails_bump/checker/bundle_locally_check_spec.rb spec/rails_bump/checker/rails_release_check_spec.rb`
- Result: `16 examples, 0 failures`

## Notes
- Refactor commit is intended to be no behavior change; it only centralizes duplicated plumbing.
