### PR TITLE
Remove unnecessary bundle clean --force

### DIFF
--- a/lib/rails_bump/checker/bundle_locally_check.rb
+++ b/lib/rails_bump/checker/bundle_locally_check.rb
@@ -82,8 +82,7 @@ module RailsBump
       def try_bundle_install
         run_bundle_install(
           gemfile_content: gemfile_content,
-          installer_options: {force: true, jobs: 4},
-          clean_bundle_cache: true
+          installer_options: {force: true, jobs: 4}
         )
       end
     end

--- a/lib/rails_bump/checker/temp_bundle_runner.rb
+++ b/lib/rails_bump/checker/temp_bundle_runner.rb
@@ -7,10 +7,8 @@ module RailsBump
     module TempBundleRunner
       private
 
-      def run_bundle_install(gemfile_content:, installer_options: {}, clean_bundle_cache: false)
+      def run_bundle_install(gemfile_content:, installer_options: {})
         with_tmp_dir do |tmp_dir|
-          `bundle clean --force` if clean_bundle_cache
-
           gemfile_path = File.join(tmp_dir, "Gemfile")
           gemfile_lock_path = File.join(tmp_dir, "Gemfile.lock")
 


### PR DESCRIPTION
Closes #22 

## Summary

- Remove `bundle clean --force` from `TempBundleRunner` and drop the `clean_bundle_cache` parameter
- This call was originally needed because `BundleLocallyCheck` wrote its temp Gemfile to a shared `tmp/` path, so stale cache could interfere between runs
- Since #27 introduced `Dir.mktmpdir`-based isolation (each run gets its own temp directory), the cache clean is no longer necessary
- The backtick invocation also silently ignored exit status and stderr, which could mask infrastructure failures as dependency incompatibilities

## Test plan

- [x] Full test suite passes (26 examples, 0 failures)