### PR TITLE
Fix endpoint resolution to respect runtime ENV changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ group :development, :test do
   gem "rspec", "~> 3.0"
   gem "simplecov"
   gem "standard", "~> 1.3"
+  gem "webmock", "~> 3.0"
 end

--- a/lib/rails_bump/checker/result_reporter.rb
+++ b/lib/rails_bump/checker/result_reporter.rb
@@ -5,7 +5,6 @@ require "json"
 module RailsBump
   module Checker
     class ResultReporter
-
       def initialize(result)
         @result = result
         @compat_id = result.compat_id.to_i

--- a/lib/rails_bump/checker/result_reporter.rb
+++ b/lib/rails_bump/checker/result_reporter.rb
@@ -5,8 +5,6 @@ require "json"
 module RailsBump
   module Checker
     class ResultReporter
-      RAILS_BUMP_HOST = ENV["RAILS_BUMP_API_HOST"] || "http://localhost:3000"
-      RESULT_ENDPOINT = URI.parse("#{RAILS_BUMP_HOST}/results")
 
       def initialize(result)
         @result = result
@@ -20,10 +18,12 @@ module RailsBump
         return puts "Skipping report because compat_id was not provided" if @compat_id.zero?
         return puts "Skipping report because RAILS_BUMP_API_KEY was not provided" if @api_key.empty?
 
-        http = Net::HTTP.new(RESULT_ENDPOINT.host, RESULT_ENDPOINT.port)
-        http.use_ssl = true if RESULT_ENDPOINT.scheme == "https"
+        endpoint = result_endpoint
 
-        request = Net::HTTP::Post.new(RESULT_ENDPOINT.path, {"Content-Type" => "application/json"})
+        http = Net::HTTP.new(endpoint.host, endpoint.port)
+        http.use_ssl = true if endpoint.scheme == "https"
+
+        request = Net::HTTP::Post.new(endpoint.path, {"Content-Type" => "application/json"})
         request["RAILS-BUMP-API-KEY"] = @api_key
 
         request.body = {
@@ -38,6 +38,13 @@ module RailsBump
 
         response = http.request(request)
         puts "Response: #{response.body} (Status: #{response.code})"
+      end
+
+      private
+
+      def result_endpoint
+        host = ENV["RAILS_BUMP_API_HOST"] || "http://localhost:3000"
+        URI.parse("#{host}/results")
       end
     end
   end

--- a/spec/rails_bump/checker/bundle_locally_check_spec.rb
+++ b/spec/rails_bump/checker/bundle_locally_check_spec.rb
@@ -1,6 +1,9 @@
 require "spec_helper"
 
 RSpec.describe RailsBump::Checker::BundleLocallyCheck do
+  before { WebMock.allow_net_connect! }
+  after { WebMock.disable_net_connect! }
+
   describe "temporary directory lifecycle" do
     it "cleans up its temporary directory without removing tmp/" do
       FileUtils.rm_rf(Dir.glob("tmp/checker-*"))

--- a/spec/rails_bump/checker/rails_release_check_spec.rb
+++ b/spec/rails_bump/checker/rails_release_check_spec.rb
@@ -1,6 +1,9 @@
 require "spec_helper"
 
 RSpec.describe RailsBump::Checker::RailsReleaseCheck do
+  before { WebMock.allow_net_connect! }
+  after { WebMock.disable_net_connect! }
+
   describe "#gemfile_content" do
     subject(:content) { checker.send(:gemfile_content) }
 

--- a/spec/rails_bump/checker/result_reporter_spec.rb
+++ b/spec/rails_bump/checker/result_reporter_spec.rb
@@ -4,6 +4,7 @@ require "webmock"
 
 RSpec.describe RailsBump::Checker::ResultReporter do
   include WebMock::API
+  include EnvHelper
 
   before { WebMock.enable! }
   after do

--- a/spec/rails_bump/checker/result_reporter_spec.rb
+++ b/spec/rails_bump/checker/result_reporter_spec.rb
@@ -28,15 +28,8 @@ RSpec.describe RailsBump::Checker::ResultReporter do
       it "uses the current ENV value" do
         stub_request(:post, "http://custom-host.test/results").to_return(status: 200, body: "ok")
 
-        original_host = ENV["RAILS_BUMP_API_HOST"]
-        original_key = ENV["RAILS_BUMP_API_KEY"]
-        begin
-          ENV["RAILS_BUMP_API_HOST"] = "http://custom-host.test"
-          ENV["RAILS_BUMP_API_KEY"] = "test-key"
+        with_env("RAILS_BUMP_API_HOST" => "http://custom-host.test", "RAILS_BUMP_API_KEY" => "test-key") do
           described_class.new(result).report
-        ensure
-          ENV["RAILS_BUMP_API_HOST"] = original_host
-          ENV["RAILS_BUMP_API_KEY"] = original_key
         end
 
         assert_requested(:post, "http://custom-host.test/results")
@@ -47,15 +40,8 @@ RSpec.describe RailsBump::Checker::ResultReporter do
       it "defaults to localhost" do
         stub_request(:post, "http://localhost:3000/results").to_return(status: 200, body: "ok")
 
-        original_host = ENV["RAILS_BUMP_API_HOST"]
-        original_key = ENV["RAILS_BUMP_API_KEY"]
-        begin
-          ENV.delete("RAILS_BUMP_API_HOST")
-          ENV["RAILS_BUMP_API_KEY"] = "test-key"
+        with_env("RAILS_BUMP_API_HOST" => nil, "RAILS_BUMP_API_KEY" => "test-key") do
           described_class.new(result).report
-        ensure
-          ENV["RAILS_BUMP_API_HOST"] = original_host
-          ENV["RAILS_BUMP_API_KEY"] = original_key
         end
 
         assert_requested(:post, "http://localhost:3000/results")

--- a/spec/rails_bump/checker/result_reporter_spec.rb
+++ b/spec/rails_bump/checker/result_reporter_spec.rb
@@ -1,0 +1,65 @@
+require "rails_bump/checker/result_reporter"
+require "rails_bump/checker/result"
+require "webmock"
+
+RSpec.describe RailsBump::Checker::ResultReporter do
+  include WebMock::API
+
+  before { WebMock.enable! }
+  after do
+    WebMock.reset!
+    WebMock.disable!
+  end
+
+  let(:result) do
+    instance_double(
+      RailsBump::Checker::Result,
+      compat_id: 123,
+      dependencies: "[]",
+      rails_version: "7.0.0",
+      success?: true,
+      output: "ok",
+      strategy: "bundler"
+    )
+  end
+
+  describe "#report" do
+    context "when RAILS_BUMP_API_HOST changes at runtime" do
+      it "uses the current ENV value" do
+        stub_request(:post, "http://custom-host.test/results").to_return(status: 200, body: "ok")
+
+        original_host = ENV["RAILS_BUMP_API_HOST"]
+        original_key = ENV["RAILS_BUMP_API_KEY"]
+        begin
+          ENV["RAILS_BUMP_API_HOST"] = "http://custom-host.test"
+          ENV["RAILS_BUMP_API_KEY"] = "test-key"
+          described_class.new(result).report
+        ensure
+          ENV["RAILS_BUMP_API_HOST"] = original_host
+          ENV["RAILS_BUMP_API_KEY"] = original_key
+        end
+
+        assert_requested(:post, "http://custom-host.test/results")
+      end
+    end
+
+    context "when RAILS_BUMP_API_HOST is not set" do
+      it "defaults to localhost" do
+        stub_request(:post, "http://localhost:3000/results").to_return(status: 200, body: "ok")
+
+        original_host = ENV["RAILS_BUMP_API_HOST"]
+        original_key = ENV["RAILS_BUMP_API_KEY"]
+        begin
+          ENV.delete("RAILS_BUMP_API_HOST")
+          ENV["RAILS_BUMP_API_KEY"] = "test-key"
+          described_class.new(result).report
+        ensure
+          ENV["RAILS_BUMP_API_HOST"] = original_host
+          ENV["RAILS_BUMP_API_KEY"] = original_key
+        end
+
+        assert_requested(:post, "http://localhost:3000/results")
+      end
+    end
+  end
+end

--- a/spec/rails_bump/checker/result_reporter_spec.rb
+++ b/spec/rails_bump/checker/result_reporter_spec.rb
@@ -1,24 +1,14 @@
-require "rails_bump/checker/result_reporter"
-require "rails_bump/checker/result"
-require "webmock"
+require "spec_helper"
 
 RSpec.describe RailsBump::Checker::ResultReporter do
-  include WebMock::API
   include EnvHelper
 
-  before { WebMock.enable! }
-  after do
-    WebMock.reset!
-    WebMock.disable!
-  end
-
   let(:result) do
-    instance_double(
-      RailsBump::Checker::Result,
+    RailsBump::Checker::Result.new(
       compat_id: 123,
-      dependencies: "[]",
+      dependencies: {},
       rails_version: "7.0.0",
-      success?: true,
+      success: true,
       output: "ok",
       strategy: "bundler"
     )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ if ENV["COVERAGE"]
 end
 
 require "rails_bump/checker"
+require "webmock/rspec"
 require_relative "support/env_helper"
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,14 +9,7 @@ if ENV["COVERAGE"]
 end
 
 require "rails_bump/checker"
-
-def with_env(overrides)
-  originals = overrides.each_key.to_h { |key| [key, ENV[key]] }
-  overrides.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
-  yield
-ensure
-  originals.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
-end
+require_relative "support/env_helper"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,14 @@ end
 
 require "rails_bump/checker"
 
+def with_env(overrides)
+  originals = overrides.each_key.to_h { |key| [key, ENV[key]] }
+  overrides.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+  yield
+ensure
+  originals.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"

--- a/spec/support/env_helper.rb
+++ b/spec/support/env_helper.rb
@@ -1,0 +1,9 @@
+module EnvHelper
+  def with_env(overrides)
+    originals = overrides.each_key.to_h { |key| [key, ENV[key]] }
+    overrides.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+    yield
+  ensure
+    originals.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+  end
+end


### PR DESCRIPTION
## Summary
- Replace `RAILS_BUMP_HOST` and `RESULT_ENDPOINT` constants with a private `result_endpoint` method that reads `ENV["RAILS_BUMP_API_HOST"]` at call time
- Add webmock dependency and tests covering endpoint resolution behavior
- Ensures runtime ENV changes are respected in long-lived processes

Closes #24

## Test plan
- [x] New specs verify custom host is used when ENV changes at runtime
- [x] New specs verify default localhost fallback
- [x] Full test suite passes (28 examples, 0 failures)