### PR TITLE
fix(actions): repair check_bundler workflow dispatch

### DIFF
--- a/.github/workflows/check_bundler.yml
+++ b/.github/workflows/check_bundler.yml
@@ -20,7 +20,8 @@ on:
         required: true
         type: string
       dependencies:
-        description: 'Dependencies in JSON format \'{"cronex":">= 0.13.0","fugit":"~> 1.8","globalid":">= 1.0.1","sidekiq":">= 6"}\''
+        description: >-
+          Dependencies in JSON format '{"cronex":">= 0.13.0","fugit":"~> 1.8","globalid":">= 1.0.1","sidekiq":">= 6"}'
         required: true
         default: '{"cronex":">= 0.13.0","fugit":"~> 1.8","globalid":">= 1.0.1","sidekiq":">= 6"}'
 

--- a/spec/github/workflows/check_bundler_workflow_spec.rb
+++ b/spec/github/workflows/check_bundler_workflow_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+require "yaml"
+
+RSpec.describe "check_bundler workflow" do
+  let(:workflow_path) do
+    File.expand_path("../../../.github/workflows/check_bundler.yml", __dir__)
+  end
+
+  it "defines a parseable workflow_dispatch trigger" do
+    workflow = YAML.safe_load_file(workflow_path)
+    trigger_config = workflow.fetch("on") { workflow.fetch(true) }
+
+    expect(trigger_config.fetch("workflow_dispatch").fetch("inputs")).to include(
+      "dependencies"
+    )
+  end
+end


### PR DESCRIPTION
The check_bundler workflow became invalid in PR #33 when the dependencies input description was changed to a single-quoted YAML scalar containing backslash-escaped single quotes. GitHub rejects that file as invalid YAML, which surfaces in railsbump/app as a 422 'Workflow does not have workflow_dispatch trigger' response when it tries to dispatch the workflow.

Replace the malformed description with a folded scalar that preserves the JSON example without breaking YAML parsing, and add a regression spec that parses the workflow file and asserts the workflow_dispatch inputs block remains loadable. This closes the gap that allowed the PR checks to pass while the dispatch-only workflow was broken.