### PR TITLE
Stop sending bundle install output in result payload

### DIFF
--- a/lib/rails_bump/checker/result_reporter.rb
+++ b/lib/rails_bump/checker/result_reporter.rb
@@ -30,7 +30,6 @@ module RailsBump
           rails_version: @rails_version,
           dependencies: @dependencies,
           success: @result.success?,
-          output: @result.output,
           strategy: @result.strategy,
           github_action_url: ENV["GITHUB_ACTION_URL"]
         }.to_json


### PR DESCRIPTION
## Summary

Stop sending the full `bundle install` output back to the app in the result payload. Only `success`, `strategy`, `dependencies`, `rails_version`, `compat_id`, and `github_action_url` are now reported.

## Context

This is the next step in hunting the web dyno memory leak on [railsbump.org](https://railsbump.org). The earlier fixes landed in the app repo:

- railsbump/app#199: excluded `status_determined_by` from `Compats::CheckUnchecked` batches (worker dyno).
- railsbump/app#200: dropped `:output` from `params[:result]` in `API::ResultsController` and stopped persisting it to `status_determined_by` (web dyno).

After deploying those PRs the web dyno RSS curve is climbing again with the same shape as before. The remaining leak is not in our persistence or controller logic, it is in Rails request logging: `ActionController::LogSubscriber` formats `filtered_parameters` on the `start_processing.action_controller` event, which fires **before** `before_action` callbacks run. So the `sanitize_result_params!` delete in #200 runs after Rails has already allocated the full `:output` string into the `Parameters:` log line, several hundred KB per POST `/results`. On a long-lived MRI web process this fragments the heap and RSS ratchets up over time.

Fixing it at the source (this PR) is strictly better than filtering on the app side:

- The 500KB body never crosses the wire.
- The app never parses it, so Rails never allocates it for logging.
- No coupling to `filter_parameters` config on the app.

The bundle install log is still available from the GitHub Actions run via `github_action_url`, which remains in the payload, so debuggability is preserved.

## Test plan

- [x] CI passes on this branch.
- [x] Deploy a test run end to end and confirm the app receives the reduced payload and the compat updates to `compatible` / `incompatible` as expected.
- [x] Watch `railsbump-production` web dyno RSS for 24h post-deploy and confirm the ratchet behavior is gone.

## Related

- railsbump/app#199
- railsbump/app#200
